### PR TITLE
Firefox scrolling on X11 instructions

### DIFF
--- a/postinst/firefox.md
+++ b/postinst/firefox.md
@@ -23,7 +23,7 @@ navigating device with touch screen
 
 </details>
 
-## on X11
+#### on X11
 
 If you are using X.Org (e.g. MATE/XFCE), then 
 

--- a/postinst/firefox.md
+++ b/postinst/firefox.md
@@ -4,7 +4,9 @@
 
 ### scrolling issue
 
-firefox on x11/xwayland dosen't let you scroll with touch screen
+## on wayland
+
+firefox on xwayland (or x11) dosen't let you scroll with touch screen
 like on mobile devices to mitigate this you should install a
 wayland compositor like [gnome](./switch-de.md)
 
@@ -20,6 +22,8 @@ so now as long as you use wayland de you should have no issue with
 navigating device with touch screen
 
 </details>
+
+## on X11
 
 If you are using X.Org (e.g. MATE/XFCE), then 
 

--- a/postinst/firefox.md
+++ b/postinst/firefox.md
@@ -21,6 +21,16 @@ navigating device with touch screen
 
 </details>
 
+If you are using X.Org (e.g. MATE/XFCE), then 
+
+1. open `about:config` in firefox to set `dom.w3c_touch_events.enabled=1` (default is 2).
+
+2. edit `/etc/security/pam_env.conf` and add `MOZ_USE_XINPUT2 DEFAULT=1`
+
+3. reboot and restart firefox
+
+Source: https://askubuntu.com/a/994483/124466
+
 ### on screen keyboard issue
 
 gnome osk (on screen keyboard) has some issue when with using backspace

--- a/postinst/firefox.md
+++ b/postinst/firefox.md
@@ -4,7 +4,7 @@
 
 ### scrolling issue
 
-## on wayland
+#### on wayland
 
 firefox on xwayland (or x11) dosen't let you scroll with touch screen
 like on mobile devices to mitigate this you should install a


### PR DESCRIPTION
Since running GNOME+wayland is not an option for devices with GPU support, we have to stay in X11 (with something like XFCE or MATE).

Here are the instructions to make touch scrolling in Firefox work with X11. 

I have verified that it works in Debian Trixie + MATE.