### PR TITLE
Add information about how to use touchscreen to emulate right click on XFCE

### DIFF
--- a/postinst/long-tap-right-click.md
+++ b/postinst/long-tap-right-click.md
@@ -59,3 +59,4 @@ sudo cp evdev-right-click-emulation/out/evdev-rce /usr/local/bin/
 sudo systemctl daemon-reload
 sudo systemctl enable long-tap-right-click.service
 sudo systemctl start long-tap-right-click.service'
+```

--- a/postinst/long-tap-right-click.md
+++ b/postinst/long-tap-right-click.md
@@ -1,0 +1,61 @@
+The default XFCE session does not play very well with touchscreens. Of course, you can switch to GNOME and KDE which use wayland and there you can long tap to emulate right click, but many devices are not powerful enough (or lack GPU driver) to run GNOME or KDE.
+Here we describe how to emulate right click behavior in XFCE by a long tap.
+
+You can do this with https://github.com/PeterCxy/evdev-right-click-emulation/
+
+First, install the build dependencies
+```
+sudo apt install build-essential git libevdev-dev
+```
+Then, download the source
+```
+git clone https://github.com/PeterCxy/evdev-right-click-emulation.git
+```
+
+Now, `go to evdev-right-click-emulation`, and change the line 19 of Makefile to the following (otherwise, it will fail to compile in recent versions of Ubuntu)
+```
+ 	$(CC) $^ -o $@ $(CFLAGS)
+```
+
+Now, let's build it.
+
+```
+cd evdev-right-click-emulation
+make all
+```
+
+If the build succeeds, it should create the binary file `out/evdev-rce`. To test it, run it with sudo,
+```
+$ sudo evdev-right-click-emulation/out/evdev-rce 
+```
+which should produce an output like
+```
+Found touch screen at /dev/input/event3: Elan Touchpad
+Found touch screen at /dev/input/event2: hid-over-i2c 06CB:7817
+```
+Afterward, long tap to enable right click should work!
+
+---
+
+Run the following command (copy paste the multi-line command into the terminal and press enter) to enable this feature permanently, once and for all! 
+(it creates a systemd service so that the program would run as root at startup)
+
+```
+sudo bash -c 'cat > /etc/systemd/system/long-tap-right-click.service <<EOF
+[Unit]
+Description=Enables long-tap-to-right-click
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/evdev-rce
+Restart=always
+User=root
+
+[Install]
+WantedBy=multi-user.target
+EOF
+sudo mkdir -p /usr/local/bin
+sudo cp evdev-right-click-emulation/out/evdev-rce /usr/local/bin/
+sudo systemctl daemon-reload
+sudo systemctl enable long-tap-right-click.service
+sudo systemctl start long-tap-right-click.service'

--- a/postinst/long-tap-right-click.md
+++ b/postinst/long-tap-right-click.md
@@ -26,7 +26,7 @@ make all
 
 If the build succeeds, it should create the binary file `out/evdev-rce`. To test it, run it with sudo,
 ```
-$ sudo evdev-right-click-emulation/out/evdev-rce 
+sudo evdev-right-click-emulation/out/evdev-rce 
 ```
 which should produce an output like
 ```

--- a/postinst/long-tap-right-click.md
+++ b/postinst/long-tap-right-click.md
@@ -14,7 +14,7 @@ Then, download the source
 git clone https://github.com/PeterCxy/evdev-right-click-emulation.git
 ```
 
-Now, `go to evdev-right-click-emulation`, and change the line 19 of Makefile to the following (otherwise, it will fail to compile in recent versions of Ubuntu)
+Now, go to `evdev-right-click-emulation` directory, and change the line 19 of Makefile to the following (otherwise, it will fail to compile in recent versions of Ubuntu/Debian)
 ```
  	$(CC) $^ -o $@ $(CFLAGS)
 ```

--- a/postinst/long-tap-right-click.md
+++ b/postinst/long-tap-right-click.md
@@ -1,4 +1,4 @@
-If your DE does not support long-tap-to-right click (e.g. XFCE) with your touchscreen, here is how you can enable it.
+If your desktop environment does not support long-tap-to-right click (e.g. XFCE) with touchscreen, here is how you can enable it.
 
 You can do this with https://github.com/PeterCxy/evdev-right-click-emulation/
 

--- a/postinst/long-tap-right-click.md
+++ b/postinst/long-tap-right-click.md
@@ -1,6 +1,9 @@
-If your desktop environment does not support long-tap-to-right click (e.g. XFCE) with touchscreen, here is how you can enable it.
+## Using touchscreen to right click
 
-You can do this with https://github.com/PeterCxy/evdev-right-click-emulation/
+Some desktop environments (DE) like XFCE do not support this feature out of the box.
+This tutorial works in both X11 and Wayland based setups, and is DE agnostic.
+
+This can be achieved with https://github.com/PeterCxy/evdev-right-click-emulation/
 
 First, install the build dependencies
 ```

--- a/postinst/long-tap-right-click.md
+++ b/postinst/long-tap-right-click.md
@@ -1,5 +1,4 @@
-The default XFCE session does not play very well with touchscreens. Of course, you can switch to GNOME and KDE which use wayland and there you can long tap to emulate right click, but many devices are not powerful enough (or lack GPU driver) to run GNOME or KDE.
-Here we describe how to emulate right click behavior in XFCE by a long tap.
+If your DE does not support long-tap-to-right click (e.g. XFCE) with your touchscreen, here is how you can enable it.
 
 You can do this with https://github.com/PeterCxy/evdev-right-click-emulation/
 
@@ -34,8 +33,6 @@ Found touch screen at /dev/input/event3: Elan Touchpad
 Found touch screen at /dev/input/event2: hid-over-i2c 06CB:7817
 ```
 Afterward, long tap to enable right click should work!
-
----
 
 Run the following command (copy paste the multi-line command into the terminal and press enter) to enable this feature permanently, once and for all! 
 (it creates a systemd service so that the program would run as root at startup)

--- a/postinst/long-tap-right-click.md
+++ b/postinst/long-tap-right-click.md
@@ -6,32 +6,32 @@ This tutorial works in both X11 and Wayland based setups, and is DE agnostic.
 This can be achieved with https://github.com/PeterCxy/evdev-right-click-emulation/
 
 First, install the build dependencies
-```
+```bash
 sudo apt install build-essential git libevdev-dev
 ```
 Then, download the source
-```
+```bash
 git clone https://github.com/PeterCxy/evdev-right-click-emulation.git
 ```
 
-Now, go to `evdev-right-click-emulation` directory, and change the line 19 of Makefile to the following (otherwise, it will fail to compile in recent versions of Ubuntu/Debian)
-```
+Now, go to `evdev-right-click-emulation` directory, and change the [line 19](https://github.com/PeterCxy/evdev-right-click-emulation/blob/350939b8d2e95ed1be352f1ac734bdedf14e43c7/Makefile#L19) of Makefile to the following (otherwise, it will fail to compile in recent versions of Ubuntu/Debian)
+```bash
  	$(CC) $^ -o $@ $(CFLAGS)
 ```
 
 Now, let's build it.
 
-```
+```bash
 cd evdev-right-click-emulation
 make all
 ```
 
 If the build succeeds, it should create the binary file `out/evdev-rce`. To test it, run it with sudo,
-```
+```bash
 sudo evdev-right-click-emulation/out/evdev-rce 
 ```
 which should produce an output like
-```
+```mk
 Found touch screen at /dev/input/event3: Elan Touchpad
 Found touch screen at /dev/input/event2: hid-over-i2c 06CB:7817
 ```
@@ -40,7 +40,7 @@ Afterward, long tap to enable right click should work!
 Run the following command (copy paste the multi-line command into the terminal and press enter) to enable this feature permanently, once and for all! 
 (it creates a systemd service so that the program would run as root at startup)
 
-```
+```bash
 sudo bash -c 'cat > /etc/systemd/system/long-tap-right-click.service <<EOF
 [Unit]
 Description=Enables long-tap-to-right-click

--- a/postinst/readme.md
+++ b/postinst/readme.md
@@ -36,6 +36,8 @@ now that you are done with installation there are some additional things you wan
 
 - touchscreen rotation adjustment (X.Org) - [touchscreen input does not rotate](./touch-input-rotate.md)
 
+- Right clicking with touchscreen in XFCE - [cannot use right click on touchscreen devices](./long-tap-right-click.md)
+
 ### other
 
 - chromebooks - [solutions to device specific issues can be found here](../chromebooks/systems/readme.md)

--- a/postinst/readme.md
+++ b/postinst/readme.md
@@ -36,7 +36,7 @@ now that you are done with installation there are some additional things you wan
 
 - touchscreen rotation adjustment (X.Org) - [touchscreen input does not rotate](./touch-input-rotate.md)
 
-- Right clicking with touchscreen in XFCE - [cannot use right click on touchscreen devices](./long-tap-right-click.md)
+- Right clicking with touchscreen - [cannot use right click on touchscreen devices](./long-tap-right-click.md)
 
 ### other
 


### PR DESCRIPTION
I cannot run GNOME/KDE (which have good touch support) in my Chromebook Hana due to lack of GPU drivers, and in XFCE, I cannot use the touchscreen alone to right click.

Here is a way to enable right click emulation in XFCE by long tapping the touchscreen.