### PR TITLE
fix broken link for camera not working on non-laptop devices

### DIFF
--- a/chromebooks/systems/readme.md
+++ b/chromebooks/systems/readme.md
@@ -25,4 +25,4 @@
 
 *Note. if your device isn't present here it doesn't mean it's not working but noone who owns the device added the docs yet, you 🫵 can always [add it yourself](../../adding-device.md)*
 
-*Note. camera doesn't work across all [no laptop devices](https://wiki.postmarketos.org/wiki/Google_Kukui_Chromebook_(google-kukui))*
+*Note. camera doesn't work across all [no laptop devices](https://wiki.postmarketos.org/wiki/Google_Kukui_Chromebook_(google-kukui)#Camera)

--- a/chromebooks/systems/readme.md
+++ b/chromebooks/systems/readme.md
@@ -23,6 +23,6 @@
 [Lenovo ideapad duet 5 (homestar)](./trogdor/homestar.md)
 [Acer chromebook spin sp513 (lazor)](./trogdor/lazor.md)
 
-*Note. if your device isn't present here it doesn't mean it's not working but noone who owns the device added the docs yet, you 🫵 can always [add it yourself](../../adding-device.md)*
+*Note. if your device isn't present here it doesn't mean it's not working but no one who owns the device added the docs yet, you 🫵 can always [add it yourself](../../adding-device.md)*
 
-*Note. camera doesn't work across all [no laptop devices](https://wiki.postmarketos.org/wiki/Google_Kukui_Chromebook_(google-kukui)#Camera)
+*Note. camera doesn't work across all [no laptop devices](https://wiki.postmarketos.org/wiki/Google_Kukui_Chromebook_(google-kukui)#Camera)*


### PR DESCRIPTION
As the hyperlink itself had a ")", it was rendered wrongly in the webpage https://velvet-os.github.io/chromebooks/systems/readme.html